### PR TITLE
Trex 431 1106

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/stats/traffic.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/stats/traffic.py
@@ -272,17 +272,16 @@ class CAstfTrafficStats(object):
         return data
 
 
-    def clear_stats(self, pid_input = DEFAULT_PROFILE_ID):
-        data = self._get_stats_values(relative = False, pid_input = pid_input)
-        if pid_input in self._ref.keys():
-            for section in self.sections:
-                self._ref[pid_input][section] = data[section]
-
-        if pid_input is DEFAULT_PROFILE_ID:
-            data = self._get_stats_values(relative = False, pid_input = pid_input, is_sum = True)
+    def clear_stats(self, pid_input = DEFAULT_PROFILE_ID, is_sum = False):
+        data = self._get_stats_values(relative = False, pid_input = pid_input, is_sum = is_sum)
+        if is_sum:
             if self._ref_global:
                 for section in self.sections:
                     self._ref_global[section] = data[section]
+        else:
+            if pid_input in self._ref.keys():
+                for section in self.sections:
+                    self._ref[pid_input][section] = data[section]
 
 
     def to_table(self, with_zeroes = False, tgid = 0, pid_input = DEFAULT_PROFILE_ID, is_sum = False):

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/stats/traffic.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/stats/traffic.py
@@ -16,28 +16,44 @@ class CAstfTrafficStats(object):
         self._ref = {}
         self.tg_names_dict = {}
 
+        self._ref_global = {}
+        self._epoch_global = 0
+        self.is_init = False
 
-    def _init_desc_and_ref(self, pid_input = DEFAULT_PROFILE_ID):
-        if pid_input in self._ref.keys():
-            return
+
+    def _init_desc_and_ref(self, pid_input = DEFAULT_PROFILE_ID, is_sum = False):
+        if is_sum:
+            if self._ref_global:
+                return
+        else:
+            if pid_input in self._ref.keys():
+                return
+
         params = {'profile_id': pid_input}
         rc = self.rpc.transmit('get_counter_desc', params = params)
-        
         if not rc:
             raise TRexError(rc.err())
 
-        self._ref[pid_input] = {}
         data = rc.data()['data']
-        self._desc = [0] * len(data)
-        self._err_desc = {}
-        for section in self.sections:
-            self._ref[pid_input][section] = [0] * len(data)
-        self._max_desc_name_len = 0
-        for item in data:
-            self._desc[item['id']] = item
-            self._max_desc_name_len = max(self._max_desc_name_len, len(item['name']))
-            if item['info'] == 'error':
-                self._err_desc[item['name']] = item
+
+        if is_sum:
+            for section in self.sections:
+                self._ref_global[section] = [0] * len(data)
+        else:
+            self._ref[pid_input] = {}
+            for section in self.sections:
+                self._ref[pid_input][section] = [0] * len(data)
+
+        if not self.is_init:
+            self._desc = [0] * len(data)
+            self._err_desc = {}
+            self._max_desc_name_len = 0
+            for item in data:
+                self._desc[item['id']] = item
+                self._max_desc_name_len = max(self._max_desc_name_len, len(item['name']))
+                if item['info'] == 'error':
+                    self._err_desc[item['name']] = item
+            self.is_init = True
 
 
     def _clear_tg_name(self, pid_input = DEFAULT_PROFILE_ID):
@@ -45,13 +61,17 @@ class CAstfTrafficStats(object):
             self.tg_names_dict.pop(pid_input)
 
 
-    def _epoch_changed(self, new_epoch, pid_input = DEFAULT_PROFILE_ID):
-        if pid_input in self._ref.keys():
-            self._ref.pop(pid_input)
-        if pid_input in self.tg_names_dict.keys():
-            self.tg_names_dict.pop(pid_input)
-        tg_info = {'epoch' : new_epoch, 'is_init' : False}  
-        self.tg_names_dict[pid_input] = tg_info
+    def _epoch_changed(self, new_epoch, pid_input = DEFAULT_PROFILE_ID, is_sum = False):
+        if is_sum:
+            self._ref_global.clear()
+            self._epoch_global = new_epoch
+        else:
+            if pid_input in self._ref.keys():
+                self._ref.pop(pid_input)
+            if pid_input in self.tg_names_dict.keys():
+                self.tg_names_dict.pop(pid_input)
+            tg_info = {'epoch' : new_epoch, 'is_init' : False}
+            self.tg_names_dict[pid_input] = tg_info
 
 
     def _translate_names_to_ids(self, tg_names, pid_input = DEFAULT_PROFILE_ID):
@@ -170,20 +190,21 @@ class CAstfTrafficStats(object):
 
 
     def _get_stats_values(self, relative = True, pid_input = DEFAULT_PROFILE_ID, is_sum = False):
-        self._init_desc_and_ref(pid_input)
+        self._init_desc_and_ref(pid_input, is_sum)
         params = {'profile_id' : pid_input}
         if is_sum:
             rc = self.rpc.transmit('get_total_counter_values', params = params)
+            ref_epoch = self._epoch_global
         else:
             rc = self.rpc.transmit('get_counter_values', params = params)
+            ref_epoch = self.tg_names_dict[pid_input]['epoch'] if pid_input in self.tg_names_dict.keys() else -1
+
         if not rc:
             raise TRexError(rc.err())
 
-        ref_epoch = self.tg_names_dict[pid_input]['epoch'] if pid_input in self.tg_names_dict.keys() else -1
-        
         data_epoch = rc.data()['epoch']
         if data_epoch != ref_epoch:
-            self._epoch_changed(data_epoch, pid_input = pid_input)
+            self._epoch_changed(data_epoch, pid_input = pid_input, is_sum = is_sum)
         data = {'epoch': data_epoch}
         for section in self.sections:
             section_list = [0] * len(self._desc)
@@ -192,8 +213,12 @@ class CAstfTrafficStats(object):
             if relative:
                 for desc in self._desc:
                     id = desc['id']
-                    if pid_input in self._ref.keys() and not desc['abs']: # return relative
-                        section_list[id] -= self._ref[pid_input][section][id]
+                    if is_sum:
+                        if self._ref_global and not desc['abs']: # return relative
+                            section_list[id] -= self._ref_global[section][id]
+                    else:
+                        if pid_input in self._ref.keys() and not desc['abs']: # return relative
+                            section_list[id] -= self._ref[pid_input][section][id]
             data[section] = section_list
         return data
 
@@ -252,6 +277,12 @@ class CAstfTrafficStats(object):
         if pid_input in self._ref.keys():
             for section in self.sections:
                 self._ref[pid_input][section] = data[section]
+
+        if pid_input is DEFAULT_PROFILE_ID:
+            data = self._get_stats_values(relative = False, pid_input = pid_input, is_sum = True)
+            if self._ref_global:
+                for section in self.sections:
+                    self._ref_global[section] = data[section]
 
 
     def to_table(self, with_zeroes = False, tgid = 0, pid_input = DEFAULT_PROFILE_ID, is_sum = False):

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/stats/traffic.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/stats/traffic.py
@@ -16,28 +16,44 @@ class CAstfTrafficStats(object):
         self._ref = {}
         self.tg_names_dict = {}
 
+        self._ref_global = {}
+        self._epoch_global = -1
+        self.is_init = False
 
-    def _init_desc_and_ref(self, pid_input = DEFAULT_PROFILE_ID):
-        if pid_input in self._ref.keys():
-            return
+
+    def _init_desc_and_ref(self, pid_input = DEFAULT_PROFILE_ID, is_sum = False):
+        if is_sum:
+            if self._ref_global:
+                return
+        else:
+            if pid_input in self._ref.keys():
+                return
+
         params = {'profile_id': pid_input}
         rc = self.rpc.transmit('get_counter_desc', params = params)
-        
         if not rc:
             raise TRexError(rc.err())
 
-        self._ref[pid_input] = {}
         data = rc.data()['data']
-        self._desc = [0] * len(data)
-        self._err_desc = {}
-        for section in self.sections:
-            self._ref[pid_input][section] = [0] * len(data)
-        self._max_desc_name_len = 0
-        for item in data:
-            self._desc[item['id']] = item
-            self._max_desc_name_len = max(self._max_desc_name_len, len(item['name']))
-            if item['info'] == 'error':
-                self._err_desc[item['name']] = item
+
+        if is_sum:
+            for section in self.sections:
+                self._ref_global[section] = [0] * len(data)
+        else:
+            self._ref[pid_input] = {}
+            for section in self.sections:
+                self._ref[pid_input][section] = [0] * len(data)
+
+        if not self.is_init:
+            self._desc = [0] * len(data)
+            self._err_desc = {}
+            self._max_desc_name_len = 0
+            for item in data:
+                self._desc[item['id']] = item
+                self._max_desc_name_len = max(self._max_desc_name_len, len(item['name']))
+                if item['info'] == 'error':
+                    self._err_desc[item['name']] = item
+            self.is_init = True
 
 
     def _clear_tg_name(self, pid_input = DEFAULT_PROFILE_ID):
@@ -45,13 +61,17 @@ class CAstfTrafficStats(object):
             self.tg_names_dict.pop(pid_input)
 
 
-    def _epoch_changed(self, new_epoch, pid_input = DEFAULT_PROFILE_ID):
-        if pid_input in self._ref.keys():
-            self._ref.pop(pid_input)
-        if pid_input in self.tg_names_dict.keys():
-            self.tg_names_dict.pop(pid_input)
-        tg_info = {'epoch' : new_epoch, 'is_init' : False}  
-        self.tg_names_dict[pid_input] = tg_info
+    def _epoch_changed(self, new_epoch, pid_input = DEFAULT_PROFILE_ID, is_sum = False):
+        if is_sum:
+            self._ref_global.clear()
+            self._epoch_global = new_epoch
+        else:
+            if pid_input in self._ref.keys():
+                self._ref.pop(pid_input)
+            if pid_input in self.tg_names_dict.keys():
+                self.tg_names_dict.pop(pid_input)
+            tg_info = {'epoch' : new_epoch, 'is_init' : False}
+            self.tg_names_dict[pid_input] = tg_info
 
 
     def _translate_names_to_ids(self, tg_names, pid_input = DEFAULT_PROFILE_ID):
@@ -170,20 +190,21 @@ class CAstfTrafficStats(object):
 
 
     def _get_stats_values(self, relative = True, pid_input = DEFAULT_PROFILE_ID, is_sum = False):
-        self._init_desc_and_ref(pid_input)
+        self._init_desc_and_ref(pid_input, is_sum)
         params = {'profile_id' : pid_input}
         if is_sum:
             rc = self.rpc.transmit('get_total_counter_values', params = params)
+            ref_epoch = self._epoch_global
         else:
             rc = self.rpc.transmit('get_counter_values', params = params)
+            ref_epoch = self.tg_names_dict[pid_input]['epoch'] if pid_input in self.tg_names_dict.keys() else -1
+
         if not rc:
             raise TRexError(rc.err())
 
-        ref_epoch = self.tg_names_dict[pid_input]['epoch'] if pid_input in self.tg_names_dict.keys() else -1
-        
         data_epoch = rc.data()['epoch']
         if data_epoch != ref_epoch:
-            self._epoch_changed(data_epoch, pid_input = pid_input)
+            self._epoch_changed(data_epoch, pid_input = pid_input, is_sum = is_sum)
         data = {'epoch': data_epoch}
         for section in self.sections:
             section_list = [0] * len(self._desc)
@@ -192,8 +213,12 @@ class CAstfTrafficStats(object):
             if relative:
                 for desc in self._desc:
                     id = desc['id']
-                    if pid_input in self._ref.keys() and not desc['abs']: # return relative
-                        section_list[id] -= self._ref[pid_input][section][id]
+                    if is_sum:
+                        if self._ref_global and not desc['abs']: # return relative
+                            section_list[id] -= self._ref_global[section][id]
+                    else:
+                        if pid_input in self._ref.keys() and not desc['abs']: # return relative
+                            section_list[id] -= self._ref[pid_input][section][id]
             data[section] = section_list
         return data
 
@@ -252,6 +277,12 @@ class CAstfTrafficStats(object):
         if pid_input in self._ref.keys():
             for section in self.sections:
                 self._ref[pid_input][section] = data[section]
+
+        if pid_input is DEFAULT_PROFILE_ID:
+            data = self._get_stats_values(relative = False, pid_input = pid_input, is_sum = True)
+            if self._ref_global:
+                for section in self.sections:
+                    self._ref_global[section] = data[section]
 
 
     def to_table(self, with_zeroes = False, tgid = 0, pid_input = DEFAULT_PROFILE_ID, is_sum = False):

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -404,9 +404,9 @@ class ASTFClient(TRexClient):
                 self.stop(False, pid_input=ALL_PROFILE_ID)
                 self.check_states(ok_states=[self.STATE_ASTF_LOADED, self.STATE_IDLE])
                 self.stop_latency()
+                self.clear_stats(ports, pid_input = ALL_PROFILE_ID)
                 self.traffic_stats.reset()
                 self.latency_stats.reset()
-                self.clear_stats(ports, pid_input = ALL_PROFILE_ID)
                 self.clear_profile(False, pid_input=ALL_PROFILE_ID)
                 self.check_states(ok_states=[self.STATE_IDLE])
                 self.set_port_attr(ports,

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -841,7 +841,7 @@ class ASTFClient(TRexClient):
                     clear_global = True,
                     clear_xstats = True,
                     clear_traffic = True,
-                    pid_input = ALL_PROFILE_ID):
+                    pid_input = DEFAULT_PROFILE_ID):
         """
             Clears statistics in given ports.
 
@@ -864,6 +864,7 @@ class ASTFClient(TRexClient):
         for profile_id in valid_pids:
             if clear_traffic:
                self.clear_traffic_stats(profile_id)
+        self.clear_traffic_stats(is_sum = True)
 
         return self._clear_stats_common(ports, clear_global, clear_xstats)
 
@@ -939,7 +940,7 @@ class ASTFClient(TRexClient):
 
 
     @client_api('getter', True)
-    def clear_traffic_stats(self, pid_input = DEFAULT_PROFILE_ID):
+    def clear_traffic_stats(self, pid_input = DEFAULT_PROFILE_ID, is_sum = False):
         """
             Clears traffic statistics.
 
@@ -948,7 +949,7 @@ class ASTFClient(TRexClient):
                     Input profile ID
 
         """
-        return self.traffic_stats.clear_stats(pid_input)
+        return self.traffic_stats.clear_stats(pid_input, is_sum)
 
 
     @client_api('getter', True)
@@ -1381,6 +1382,21 @@ class ASTFClient(TRexClient):
             raise TRexError('Unhandled command %s' % opts.command)
 
         return True
+
+
+    @console_api('clear', 'common', False)
+    def clear_stats_line (self, line):
+        '''Clear cached local statistics\n'''
+        # define a parser
+        parser = parsing_opts.gen_parser(self,
+                                         "clear",
+                                         self.clear_stats_line.__doc__,
+                                         parsing_opts.PORT_LIST_WITH_ALL)
+
+        opts = parser.parse_args(line.split())
+        self.clear_stats(opts.ports, pid_input = ALL_PROFILE_ID)
+
+        return RC_OK()
 
 
     @console_api('stats', 'common', True)

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -404,6 +404,8 @@ class ASTFClient(TRexClient):
                 self.stop(False, pid_input=ALL_PROFILE_ID)
                 self.check_states(ok_states=[self.STATE_ASTF_LOADED, self.STATE_IDLE])
                 self.stop_latency()
+                self.traffic_stats.reset()
+                self.latency_stats.reset()
                 self.clear_stats(ports, pid_input = ALL_PROFILE_ID)
                 self.clear_profile(False, pid_input=ALL_PROFILE_ID)
                 self.check_states(ok_states=[self.STATE_IDLE])

--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_client.py
@@ -841,7 +841,7 @@ class ASTFClient(TRexClient):
                     clear_global = True,
                     clear_xstats = True,
                     clear_traffic = True,
-                    pid_input = DEFAULT_PROFILE_ID):
+                    pid_input = ALL_PROFILE_ID):
         """
             Clears statistics in given ports.
 

--- a/scripts/automation/trex_control_plane/interactive/trex/console/trex_tui.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/console/trex_tui.py
@@ -302,7 +302,7 @@ class TrexTUIAstfTrafficStats(TrexTUIPanel):
 
 
     def action_clear(self):
-         self.client.clear_traffic_stats()
+         self.client.clear_stats()
          return ""
 
     def action_up(self):


### PR DESCRIPTION
For internal code review
**1. "clear_stats" to be applied to ALL_PROFILE_ID by default (no pid parameter given)**
-> by using "clear -a" command without a profile param, user can remove all profiles
**2. "reference stats values (_ref)" in CAstfTrafficStats(traffic.py) to manage all reference values in dictionary by PID**
**3. traffic_stats.reset() and latency_stats.reset() when reset() used in ASTFClient (trex_astf_client.py)**