### PR TITLE
Toggle for GARP requests in pretest

### DIFF
--- a/src/main_dpdk.cpp
+++ b/src/main_dpdk.cpp
@@ -227,6 +227,7 @@ enum {
        OPT_DISABLE_IEEE_1588,
        OPT_LATENCY_DIAG,
        OPT_DEFER_START_QUEUES,
+       OPT_GARP_IGNORE,
 
        /* no more pass this */
        OPT_MAX
@@ -327,6 +328,7 @@ static CSimpleOpt::SOption parser_options[] =
         { OPT_DISABLE_IEEE_1588,      "--disable-ieee-1588", SO_NONE},
         { OPT_LATENCY_DIAG,           "--latency-diag", SO_NONE},
         { OPT_DEFER_START_QUEUES,     "--defer-start-queues", SO_NONE},
+        { OPT_GARP_IGNORE,            "--ignore-garp", SO_NONE},
 
         SO_END_OF_OPTIONS
     };
@@ -364,6 +366,7 @@ static int COLD_FUNC  usage() {
     printf("                               so we do not call them by default for now. Leaving this as option in case someone thinks it is helpful for him \n");
     printf("                               This it temporary option. Will be removed in the future \n");
     printf(" -d                         : Duration of the test in sec (default is 3600). Look also at --nc \n");
+    printf(" --ignore-garp              : Ignore received gratuitous ARPs for setting port addresses during setup. Default is false.\n");
     printf(" -e                         : Like -p but src/dst IP will be chosen according to the port (i.e. on client port send all packets with client src and server dest, and vice versa on server port \n");
     printf(" --flip                     : Each flow will be sent both from client to server and server to client. This can achieve better port utilization when flow traffic is asymmetric \n");
     printf(" --hdrh                     : Report latency using high dynamic range histograms (http://hdrhistogram.org)\n");
@@ -974,6 +977,9 @@ COLD_FUNC static int parse_options(int argc, char *argv[], bool first_time ) {
                 break;
             case OPT_DEFER_START_QUEUES:
                 po->preview.set_defer_start_queues(true);
+                break;
+            case OPT_GARP_IGNORE:
+                po->m_garp_ignore = true;
                 break;
 
             default:

--- a/src/pre_test.cpp
+++ b/src/pre_test.cpp
@@ -526,10 +526,15 @@ int CPretest::handle_rx(int port_id, int queue_id) {
                             }
                         }
                     } else {
-                        // ARP request not to our IP. Check if this is gratitues ARP for something we need.
+                        // ARP request not to our IP. Check if this is gratuitous ARP for something we need.
                         if ((arp->m_arp_tip == arp->m_arp_sip)
-                            && (rcv_addr = port->find_next_hop(ntohl(arp->m_arp_tip), vlan_id))) {
+                            && (rcv_addr = port->find_next_hop(ntohl(arp->m_arp_tip), vlan_id))
+                            && !CGlobalInfo::m_options.m_garp_ignore) {
                             rcv_addr->set_mac((uint8_t *)&arp->m_arp_sha);
+                            fprintf(stdout, "RX grat ARP request for something we need on port:%d sip:%s, tip:%s\n",
+                                    port_id,
+                                    ip_to_str(ntohl(arp->m_arp_sip)).c_str(), 
+                                    ip_to_str(ntohl(arp->m_arp_tip)).c_str());
                         }
                     }
                 } else {

--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -636,6 +636,7 @@ public:
         m_tunnel_loopback = false;
         m_tunnel_enabled = false;
         m_rx_dp_ring_size = 0;
+        m_garp_ignore = false;
     }
 
     CParserOption(){
@@ -709,6 +710,7 @@ public:
     bool            m_astf_best_effort_mode;
     bool            m_tunnel_loopback;
     uint16_t        m_rx_dp_ring_size;              // Size of rings between Dp and Rx.
+    bool            m_garp_ignore;
 
 
 public:


### PR DESCRIPTION
Adds toggle to trex-core for toggling the usage
of GARP requests in pretest on and off.
Default behaviour is as before, the parameter when set ignores GARPs during pretest.