### PR TITLE
Tune TCP parameters to decrease the TCP ramp up time

### DIFF
--- a/doc/trex_astf.asciidoc
+++ b/doc/trex_astf.asciidoc
@@ -3915,7 +3915,7 @@ link:cp_astf_docs/index.html[python index]
 |   tcp.keepidle    |2-65533|5|-|+| value in second for TCP keepidle
 |   tcp.keepintvl   |2-65533|7|-|+| value in second for TCP keepalive interval
 |   tcp.blackhole   |0,1,2|0|-|+| 0 - return RST packet in case of error. 1- return of RST only in SYN. 2- don't return any RST packet, make a blackhole.
-|   tcp.delay_ack_msec | 20-50000|100|-|+| delay ack timeout in msec.  Reducing this value will reduce the performance but will reduce the active flows
+|   tcp.delay_ack_msec | 1-50000|100|-|+| delay ack timeout in msec.  Reducing this value will reduce the performance but will reduce the active flows
 |   tcp.no_delay    | 0-3   | 0|+|+| 2 bits: LSB - Nagle Algorithm (0 - Enabled, 1 - Disabled). MSB - Force Push (FP) (0 - Disabled, 1 - Enabled).
 |   tcp.no_delay_counter    | 0-65533   | 0|+|+|  number of recv bytes to wait until ack is sent. notice ack can be triggered by tcp timer, in order to ensure fixed number of sent packets until ack you should increase the *tcp.initwnd* tunable. otherwise no_delay_counter will race with the tcp timer.
 |   scheduler.rampup_sec    | 3-60000  | disabled |-|+|  scheduler rampup in seconds. After this time the throughput would be the maximum. the throughput increases linearly every 1 sec.

--- a/src/44bsd/netinet/cc/cc_newreno.c
+++ b/src/44bsd/netinet/cc/cc_newreno.c
@@ -67,7 +67,7 @@ extern int tcp_compute_pipe(struct tcpcb *);
 /* tcp_subr.c */
 extern u_int tcp_maxseg(const struct tcpcb *);
 
-#define V_tcp_abc_l_var     2
+#define V_tcp_abc_l_var     44
 #define V_tcp_do_rfc3465    1
 
 #define V_cc_do_abe             0

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1076,7 +1076,7 @@ bool CAstfDB::read_tunables(CTcpTuneables *tune, Json::Value tune_json) {
             }
 
             if (read_tunable_uint16(tune,json,"delay_ack_msec",CTcpTuneables::tcp_delay_ack,tune->m_tcp_delay_ack_msec)){
-                tunable_min_max_u32("delay_ack_msec",tune->m_tcp_delay_ack_msec,20,50000);
+                tunable_min_max_u32("delay_ack_msec",tune->m_tcp_delay_ack_msec,1,50000);
             }
 
             if (read_tunable_uint16(tune, json, "no_delay_counter", CTcpTuneables::tcp_no_delay_counter,tune->m_tcp_no_delay_counter)){

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -155,7 +155,7 @@ class CTcpTuneables {
     uint16_t  m_tcp_keepinit;
     uint16_t  m_tcp_keepidle;
     uint16_t  m_tcp_keepintvl;
-    uint16_t m_tcp_delay_ack_msec; /* 20-500msec */
+    uint16_t m_tcp_delay_ack_msec; /* 1-500msec */
 
     uint16_t m_tcp_mss;
     uint16_t m_tcp_initwnd; /* init window*/


### PR DESCRIPTION
Set the value of "V_tcp_abc_l_var" to 44 to allow the congestion window to increase in bigger steps.

Change the min value of "tcp.delay_ack_msec" 1ms to be able to decrease the time before acks are sent.