### PR TITLE
Allow TCP congestion window to increase faster

### DIFF
--- a/src/44bsd/netinet/cc/cc_newreno.c
+++ b/src/44bsd/netinet/cc/cc_newreno.c
@@ -67,7 +67,7 @@ extern int tcp_compute_pipe(struct tcpcb *);
 /* tcp_subr.c */
 extern u_int tcp_maxseg(const struct tcpcb *);
 
-#define V_tcp_abc_l_var     2
+#define V_tcp_abc_l_var     44
 #define V_tcp_do_rfc3465    1
 
 #define V_cc_do_abe             0


### PR DESCRIPTION
Set the value of "V_tcp_abc_l_var" to 44 to allow the congestion window to increase in bigger steps. This value is configurable in the BSD implementation. It was previously set to 2, which is the default value in BSD.