### PR TITLE
Make it possible to tune tcp_abc_l_var

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_global_info.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_global_info.py
@@ -126,6 +126,7 @@ class ASTFGlobalInfo(ASTFGlobalInfoBase):
                 {"name": "do_ecn", "type": [int]},
                 {"name": "cc_algo", "type": [int]},
                 {"name": "reass_maxqlen", "type": [int]},
+                {"name": "abc_l_var", "type": [int]},
             ],
         "ip": [
             {"name": "tos", "type": [int]},

--- a/src/44bsd/netinet/cc/cc_newreno.c
+++ b/src/44bsd/netinet/cc/cc_newreno.c
@@ -150,7 +150,6 @@ newreno_ack_received(struct cc_var *ccv, uint16_t type)
              * XXXLAS: Find a way to signal SS after RTO that
              * doesn't rely on tcpcb vars.
              */
-            printf("!!!!!!!!!!!!!!!!! V_tcp_abc_l_var = %d !!!!!!!!!!!!!!!!", ccv->ccvc.tcp->t_tune->tcp_abc_l_var);
             if (CCV(ccv, snd_nxt) == CCV(ccv, snd_max))
                 incr = min(ccv->bytes_this_ack,
                     ccv->nsegs * ccv->ccvc.tcp->t_tune->tcp_abc_l_var *

--- a/src/44bsd/netinet/cc/cc_newreno.c
+++ b/src/44bsd/netinet/cc/cc_newreno.c
@@ -58,7 +58,6 @@
 
 #include "sys_inet.h"
 #include "tcp_var.h"
-#include <stdio.h>
 
 #include "cc/cc_newreno.h"
 

--- a/src/44bsd/netinet/cc/cc_newreno.c
+++ b/src/44bsd/netinet/cc/cc_newreno.c
@@ -67,7 +67,7 @@ extern int tcp_compute_pipe(struct tcpcb *);
 /* tcp_subr.c */
 extern u_int tcp_maxseg(const struct tcpcb *);
 
-#define V_tcp_abc_l_var     2
+#define V_tcp_abc_l_var     44
 #define V_tcp_do_rfc3465    1
 
 #define V_cc_do_abe             0

--- a/src/44bsd/netinet/cc/cc_newreno.c
+++ b/src/44bsd/netinet/cc/cc_newreno.c
@@ -58,6 +58,7 @@
 
 #include "sys_inet.h"
 #include "tcp_var.h"
+#include <stdio.h>
 
 #include "cc/cc_newreno.h"
 
@@ -149,9 +150,10 @@ newreno_ack_received(struct cc_var *ccv, uint16_t type)
              * XXXLAS: Find a way to signal SS after RTO that
              * doesn't rely on tcpcb vars.
              */
+            printf("!!!!!!!!!!!!!!!!! V_tcp_abc_l_var = %d !!!!!!!!!!!!!!!!", ccv->ccvc.tcp->t_tune->tcp_abc_l_var);
             if (CCV(ccv, snd_nxt) == CCV(ccv, snd_max))
                 incr = min(ccv->bytes_this_ack,
-                    ccv->nsegs * V_tcp_abc_l_var *
+                    ccv->nsegs * ccv->ccvc.tcp->t_tune->tcp_abc_l_var *
                     CCV(ccv, t_maxseg));
             else
                 incr = min(ccv->bytes_this_ack, CCV(ccv, t_maxseg));

--- a/src/44bsd/netinet/cc/cc_newreno.c
+++ b/src/44bsd/netinet/cc/cc_newreno.c
@@ -67,7 +67,6 @@ extern int tcp_compute_pipe(struct tcpcb *);
 /* tcp_subr.c */
 extern u_int tcp_maxseg(const struct tcpcb *);
 
-#define V_tcp_abc_l_var     44
 #define V_tcp_do_rfc3465    1
 
 #define V_cc_do_abe             0

--- a/src/44bsd/netinet/tcp_var.h
+++ b/src/44bsd/netinet/tcp_var.h
@@ -554,7 +554,6 @@ struct tcp_tune {
 #define V_tcp_do_rfc1323            TCP_TUNE(tcp_do_rfc1323)           // 1
 #define V_tcprexmtthresh            TCP_TUNE(tcprexmtthresh)           // 3
 #define V_tcp_delacktime            TCP_TUNE(tcp_delacktime)
-#define V_tcp_abc_l_var             TCP_TUNE(tcp_abc_l_var)
 
 /* inline functions from tcp_timer.c */
 

--- a/src/44bsd/netinet/tcp_var.h
+++ b/src/44bsd/netinet/tcp_var.h
@@ -555,6 +555,7 @@ struct tcp_tune {
 #define V_tcprexmtthresh            TCP_TUNE(tcprexmtthresh)           // 3
 #define V_tcp_delacktime            TCP_TUNE(tcp_delacktime)
 
+
 /* inline functions from tcp_timer.c */
 
 #define tcp_getticks(tp)        *((tp)->m_timer.now_tick)

--- a/src/44bsd/netinet/tcp_var.h
+++ b/src/44bsd/netinet/tcp_var.h
@@ -517,6 +517,7 @@ struct tcp_tune {
     int tcp_keepintvl;      /* (TCPTV_KEEPINTVL) time between keepalive probes */
     int tcp_keepcnt;        /* (TCPTV_KEEPCNT) Number of keepalive probes to send */
     int tcp_delacktime;     /* (TCPTV_DELACK) Time before a delayed ACK is sent */
+    int tcp_abc_l_var;      /* Multiplier to calculate the step size for congestion window (abc_l_var * mssdflt) */
 };
 
 #define TCP_TUNE(name)              tp->t_tune->name
@@ -553,7 +554,7 @@ struct tcp_tune {
 #define V_tcp_do_rfc1323            TCP_TUNE(tcp_do_rfc1323)           // 1
 #define V_tcprexmtthresh            TCP_TUNE(tcprexmtthresh)           // 3
 #define V_tcp_delacktime            TCP_TUNE(tcp_delacktime)
-
+#define V_tcp_abc_l_var             TCP_TUNE(tcp_abc_l_var)
 
 /* inline functions from tcp_timer.c */
 

--- a/src/44bsd/tcp_subr.cpp
+++ b/src/44bsd/tcp_subr.cpp
@@ -719,6 +719,7 @@ CTcpTunableCtx::CTcpTunableCtx() {
     tcp_ttl=0;
 
     tcp_reass_maxqlen = 100;
+    tcp_abc_l_var = 2;
 }
 
 void CTcpTunableCtx::update_tuneables(CTcpTuneables *tune) {
@@ -801,6 +802,10 @@ void CTcpTunableCtx::update_tuneables(CTcpTuneables *tune) {
 
     if (tune->is_valid_field(CTcpTuneables::tcp_reass_maxqlen)) {
         tcp_reass_maxqlen = (int)tune->m_tcp_reass_maxqlen;
+    }
+
+    if (tune->is_valid_field(CTcpTuneables::tcp_abc_l_var)) {
+        tcp_abc_l_var = (int)tune->m_tcp_abc_l_var;
     }
 }
 

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1103,6 +1103,10 @@ bool CAstfDB::read_tunables(CTcpTuneables *tune, Json::Value tune_json) {
             if (read_tunable_uint16(tune,json,"reass_maxqlen",CTcpTuneables::tcp_reass_maxqlen,tune->m_tcp_reass_maxqlen)){
                 tunable_min_max_u32("reass_maxqlen",tune->m_tcp_reass_maxqlen,0,1000);
             }
+
+            if (read_tunable_uint16(tune,json,"abc_l_var",CTcpTuneables::tcp_abc_l_var,tune->m_tcp_abc_l_var)){
+                tunable_min_max_u32("abc_l_var",tune->m_tcp_abc_l_var,2,65533);
+            }
         }
 
         if (tune_json["ipv6"] != Json::nullValue) {

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -124,8 +124,8 @@ class CTcpTuneables {
         m_tcp_cc_algo=0;
         m_tcp_do_ecn=0;
 
-        m_tcp_reass_maxqlen = 0;
-        m_tcp_abc_l_var = 0;
+        m_tcp_reass_maxqlen=0;
+        m_tcp_abc_l_var=0;
 
         memset(m_ipv6_src,0,16);
         memset(m_ipv6_dst,0,16);

--- a/src/astf/astf_db.h
+++ b/src/astf/astf_db.h
@@ -88,6 +88,7 @@ class CTcpTuneables {
         tcp_do_ecn      = 0x800000,
 
         tcp_reass_maxqlen = 0x1000000,
+        tcp_abc_l_var = 0x2000000,
     };
     enum {
         no_delay_mask_nagle = 0x1,
@@ -123,7 +124,8 @@ class CTcpTuneables {
         m_tcp_cc_algo=0;
         m_tcp_do_ecn=0;
 
-        m_tcp_reass_maxqlen=0;
+        m_tcp_reass_maxqlen = 0;
+        m_tcp_abc_l_var = 0;
 
         memset(m_ipv6_src,0,16);
         memset(m_ipv6_dst,0,16);
@@ -176,6 +178,7 @@ class CTcpTuneables {
     uint8_t  m_tcp_cc_algo;
 
     uint16_t  m_tcp_reass_maxqlen;
+    uint16_t  m_tcp_abc_l_var;
 
  private:
     uint32_t m_bitfield;


### PR DESCRIPTION
Make it possible to tune the parameter "tcp_abc_l_var". This will allow the congestion window to increase in bigger steps.
This value is configurable in the BSD implementation. It was previously hardcoded to 2, which is the default value in BSD.