### PR TITLE
Add RSS rte flow for the GTP inner header.

### DIFF
--- a/src/trex_global.h
+++ b/src/trex_global.h
@@ -645,6 +645,7 @@ public:
         m_tunnel_enabled = false;
         m_rx_dp_ring_size = 0;
         m_garp_ignore = false;
+        m_rss_gtp = false;
     }
 
     CParserOption(){
@@ -719,6 +720,7 @@ public:
     bool            m_tunnel_loopback;
     uint16_t        m_rx_dp_ring_size;              // Size of rings between Dp and Rx.
     bool            m_garp_ignore;
+    bool            m_rss_gtp;
 
 
 public:


### PR DESCRIPTION
Added RSS rte flow to be used on NICs that support GTP tunnel traffic filtering.

This should be run with the --rss-gtp flag.
In case the NIC expects that, specific firmware configuration also should be set on the NIC.