### PR TITLE
Remove condition for checking l7 data in tcp_socket

### DIFF
--- a/src/44bsd/tcp_socket.cpp
+++ b/src/44bsd/tcp_socket.cpp
@@ -828,9 +828,7 @@ int CEmulApp::on_bh_rx_bytes(uint32_t rx_bytes,
                             struct rte_mbuf * m){
     set_interrupt(true);
     if (m) {
-        if (m_program->is_stream()) {
-            check_l7_data(m);
-        }
+        check_l7_data(m);
         /* for now do nothing with the mbuf */
         rte_pktmbuf_free(m);
     }


### PR DESCRIPTION
It's checked by m_l7check_enable anyway.