### PR TITLE
Add option rand_client_port to ASTFProfile

### DIFF
--- a/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
+++ b/scripts/automation/trex_control_plane/interactive/trex/astf/trex_astf_profile.py
@@ -1977,7 +1977,7 @@ class ASTFProfile(object):
     """
 
     def __init__(self, default_ip_gen, default_c_glob_info=None, default_s_glob_info=None,
-                 templates=None, cap_list=None, s_delay=None, udp_mtu=None):
+                 templates=None, cap_list=None, s_delay=None, udp_mtu=None, rand_client_port=False):
         """
         Define a ASTF profile
 
@@ -2007,6 +2007,10 @@ class ASTFProfile(object):
                   udp_mtu: int or None
                       MTU for udp packets, if packets exceeding the specified value they will be cut down from L7 in order to fit.
                       This will be applied on all cap in cap list, unless cap specified his own udp_mtu. defaults to None.
+
+                  rand_client_port : bool
+                      Use a random start port every time a client is created.
+                      Default is false, which means that start port is based on thread id.
         """
 
         ver_args = {"types":
@@ -2025,6 +2029,10 @@ class ASTFProfile(object):
         self.templates = []
         self.tg_name_to_id = collections.OrderedDict()
         self.cache = ASTFProfileCache(profile = self)
+
+        self.fields = {
+            'rand_client_port': rand_client_port,
+        }
 
         if (templates is None) and (cap_list is None):
              raise ASTFErrorBadParamCombination(self.__class__.__name__, "templates", "cap_list")
@@ -2150,6 +2158,7 @@ class ASTFProfile(object):
         # Remember! If tg_name = None then tg_id = 0 and tg_name is not passed to the server. As such
         # when parsing the JSON in the server be careful to pay attention that the first tg_name belongs to
         # tg_id = 1.
+        ret['rand_client_port'] = self.fields['rand_client_port']
         return ret;
 
     @pretty_exceptions

--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1345,7 +1345,8 @@ CAstfTemplatesRW *CAstfDB::get_db_template_rw(uint8_t socket_id, CTupleGenerator
             gen_idx_trans.push_back(last_c_idx);
             last_c_idx++;
             ClientCfgDB  * cdb=get_client_cfg_db();
-            g_gen->add_client_pool(dist, portion.m_ip_start, portion.m_ip_end, active_flows_per_core, *cdb, 0, 0);
+            bool rand_client_port = m_val["rand_client_port"].asBool();
+            g_gen->add_client_pool(dist, portion.m_ip_start, portion.m_ip_end, active_flows_per_core, *cdb, 0, 0, rand_client_port);
         } else {
             gen_idx_trans.push_back(last_s_idx);
             last_s_idx++;

--- a/src/rand_gen.h
+++ b/src/rand_gen.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <random>
+
+uint64_t entropy64() {
+    std::random_device src;
+    return (uint64_t(src()) << 32) | src();
+}
+
+struct XorShift32Star final {
+    explicit XorShift32Star(uint64_t seed) : state(seed | 1) {} // state must be non-zero
+    explicit XorShift32Star() : XorShift32Star(entropy64()) {}
+
+    using result_type = uint32_t;
+
+    static constexpr result_type min() { return std::numeric_limits<result_type>::min(); }
+    static constexpr result_type max() { return std::numeric_limits<result_type>::max(); }
+    
+    result_type operator()() {
+        state ^= state >> 11;
+        state ^= state << 31;
+        state ^= state >> 18;
+        return (state * 0xd989bcacc137dcd5ULL) >> 32;
+    }
+    
+    private:
+    uint64_t state;
+};

--- a/src/tuple_gen.h
+++ b/src/tuple_gen.h
@@ -748,6 +748,7 @@ public:
         m_rss_thread_max=0;
         m_reta_mask=0;
         m_rss_astf_mode=false;
+        m_rand_client_port=false;
         m_active_clients.Create();
         set_active_list_ptr_to_start();
     }
@@ -830,7 +831,8 @@ public:
                 double          active_flows,
                 ClientCfgDB     &client_info,
                 uint16_t        tcp_aging,
-                uint16_t        udp_aging); 
+                uint16_t        udp_aging,
+                bool            rand_client_port = false); 
 
 
     void set_thread_id(uint16_t thread_id){
@@ -857,6 +859,7 @@ public:
     uint16_t m_rss_thread_max;
     uint8_t  m_reta_mask;
     bool     m_rss_astf_mode;
+    bool     m_rand_client_port;
 
     CFlowGenListPerThread* m_thread_ptr;
 
@@ -1057,7 +1060,8 @@ public:
                          double        active_flows,
                          ClientCfgDB   &client_info,
                          uint16_t      tcp_aging,
-                         uint16_t      udp_aging);
+                         uint16_t      udp_aging,
+                         bool          rand_client_port = false);
 
     bool add_server_pool(IP_DIST_t  server_dist,
                          uint32_t   min_server,


### PR DESCRIPTION
If the rand_client_port option is set to true, a random start port will be generated with uniform distribution for each new client pool. The start port is used when creating new ports for a client. This gives random client ports when a client is running flows sequencially.

If not set, the start port will be generated based on thread_id as before. This give one port per thread when a client is running flows sequentially.

The behaviour when a client runs multiple flows in parallel has not been modified.

Usage:
ASTFProfile(default_ip_gen=ip_gen,
            templates=template,
            rand_client_port=True)