### PR TITLE
Align ASTF IP address and flow count split

### DIFF
--- a/src/astf/astf_db.cpp
+++ b/src/astf/astf_db.cpp
@@ -1259,7 +1259,8 @@ void CAstfDB::get_thread_ip_range(uint16_t thread_id, uint16_t max_threads, uint
         fill_rss_vals(thread_id, rss_thread_id, rss_thread_max);
         split_ips(rss_thread_id, rss_thread_max, dual_port_id, poolinfo, portion);
     }else{
-        split_ips(thread_id, max_threads, dual_port_id, poolinfo, portion);
+        uint16_t split_id = (thread_id+m_core_base)%max_threads;
+        split_ips(split_id, max_threads, dual_port_id, poolinfo, portion);
     }
 }
 
@@ -1338,7 +1339,8 @@ CAstfTemplatesRW *CAstfDB::get_db_template_rw(uint8_t socket_id, CTupleGenerator
         } else if (poolinfo.m_per_core_distro) {
             split_ips(rss_thread_id, rss_thread_max, dual_port_id, poolinfo, portion);
         }else{
-            split_ips(thread_id, max_threads, dual_port_id, poolinfo, portion);
+            uint16_t split_id = (thread_id+m_core_base)%max_threads;
+            split_ips(split_id, max_threads, dual_port_id, poolinfo, portion);
         }
         active_flows_per_core = (portion.m_ip_end - portion.m_ip_start) * 32000;
         if (ip_gen_list[i]["dir"] == "c") {

--- a/src/utils/utl_split.h
+++ b/src/utils/utl_split.h
@@ -31,7 +31,7 @@ inline uint32_t utl_split_int(uint32_t val,
     assert(thread_id<num_threads);
     uint32_t s=val/num_threads;
     uint32_t m=val%num_threads;
-    if (thread_id<m) {
+    if (thread_id>=num_threads - m) {
         s+=1;
     }
     return(s);


### PR DESCRIPTION
For ASTF templates, the distribution of IP addresses and flow counts were previously independent. In cases where the numbers of IPs were not a multiple of the number of threads, it sometimes led to that not all IPs were used. The reason for this was that residue IPs where always put on the same threads, but the residue flow count was randomly distributed. The result was that a thread with fewer IPs could get a higher flow count, and a thread with more IPs could get a lower flow count. The first IPs on the thread with fewer IPs were then repeated, and the last IPs on the thread with more IPs were never used.

With this change the IPs and the flow counts are distributed in the same way based on the random distribution previously used for flow counts. In cases where the number of IPs is equal to the flow count, all IPs will now be used.